### PR TITLE
Add QuadTransformerBlankToNamed

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,6 +430,28 @@ Options:
 * `"searchRegex"`: The regex to search for.
 * `"replacementString"`: The string to replace.
 
+#### Replace BlankNode by NamedNode Transformer
+
+A quad transformer that replaces BlankNodes by NamedNodes if the node-value changes when performing search/ replacement.
+
+```json
+{
+  "transformers": [
+    {
+      "@type": "QuadTransformerBlankToNamed",
+      "searchRegex": "^b0_tagclass",
+      "replacementString": "http://localhost:3000/www.ldbc.eu/tag"
+    }
+  ]
+}
+```
+
+This supports group-based replacements just like the [QuadTransformerReplaceIri](#replace-iri-quad-transformer)
+
+Options:
+* `"searchRegex"`: The regex to search for.
+* `"replacementString"`: The string to replace.
+
 #### Remap Resource Identifier Transformer
 
 A quad transformer that matches all resources of the given type,

--- a/index.ts
+++ b/index.ts
@@ -30,6 +30,7 @@ export * from './lib/transform/QuadTransformerAppendResourceAdapter';
 export * from './lib/transform/QuadTransformerAppendResourceLink';
 export * from './lib/transform/QuadTransformerAppendResourceScl';
 export * from './lib/transform/QuadTransformerAppendResourceSolidTypeIndex';
+export * from './lib/transform/QuadTransformerBlankToNamed';
 export * from './lib/transform/QuadTransformerClone';
 export * from './lib/transform/QuadTransformerCompositeSequential';
 export * from './lib/transform/QuadTransformerCompositeVaryingResource';

--- a/lib/transform/QuadTransformerBlankToNamed.ts
+++ b/lib/transform/QuadTransformerBlankToNamed.ts
@@ -1,0 +1,30 @@
+import type * as RDF from '@rdfjs/types';
+import { DataFactory } from 'rdf-data-factory';
+import { QuadTransformerTerms } from './QuadTransformerTerms';
+
+const DF = new DataFactory();
+
+/**
+ * A quad transformer that replaces BlankNodes by NamedNodes if the node-value changes when performing
+ * search/ replacement.
+ */
+export class QuadTransformerBlankToNamed extends QuadTransformerTerms {
+  private readonly search: RegExp;
+  private readonly replacement: string;
+
+  public constructor(searchRegex: string, replacementString: string) {
+    super();
+    this.search = new RegExp(searchRegex, 'u');
+    this.replacement = replacementString;
+  }
+
+  protected transformTerm(term: RDF.Term): RDF.Term {
+    if (term.termType === 'BlankNode') {
+      const value = term.value.replace(this.search, this.replacement);
+      if (value !== term.value) {
+        return DF.namedNode(value);
+      }
+    }
+    return term;
+  }
+}

--- a/lib/transform/QuadTransformerCompositeVaryingResource.ts
+++ b/lib/transform/QuadTransformerCompositeVaryingResource.ts
@@ -7,7 +7,7 @@ const DF = new DataFactory();
 
 /**
  * A quad transformer that wraps over other quad transformers,
- * and varies between based based on the configured resource type.
+ * and varies based on the configured resource type.
  *
  * Concretely, it will match all resources of the given type,
  * and evenly distribute these resources to the different quad transformers.

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "test": "jest ${1}",
     "test-watch": "jest ${1} --watch",
     "lint": "eslint . --ext .ts --cache",
+    "lint:fix": "eslint . --ext .ts --cache --fix",
     "build": "npm run build:ts && npm run build:components",
     "build:components": "componentsjs-generator -s lib -r rdfdf",
     "build:ts": "tsc",

--- a/test/unit/transform/QuadTransformerBlankToNamed-test.ts
+++ b/test/unit/transform/QuadTransformerBlankToNamed-test.ts
@@ -1,0 +1,70 @@
+import { DataFactory } from 'rdf-data-factory';
+import type { IQuadTransformer } from '../../../lib/transform/IQuadTransformer';
+import { QuadTransformerBlankToNamed } from '../../../lib/transform/QuadTransformerBlankToNamed';
+
+const DF = new DataFactory();
+
+describe('QuadTransformerBlankToNamed', () => {
+  let transformer: IQuadTransformer;
+
+  describe('with a simple search and replace', () => {
+    beforeEach(() => {
+      transformer = new QuadTransformerBlankToNamed('^tagclass', 'http://www.example.org/tagclass');
+    });
+
+    describe('transform', () => {
+      it('should modify applicable terms', async() => {
+        expect(transformer.transform(DF.quad(
+          DF.blankNode('tagclass000098'),
+          DF.namedNode('ex:p'),
+          DF.literal('o'),
+        ))).toEqual([
+          DF.quad(
+            DF.namedNode('http://www.example.org/tagclass000098'),
+            DF.namedNode('ex:p'),
+            DF.literal('o'),
+          ),
+        ]);
+      });
+
+      it('should not modify non-applicable terms', async() => {
+        expect(transformer.transform(DF.quad(
+          DF.namedNode('http://something.ldbc.eu/a.ttl'),
+          DF.namedNode('ex:p'),
+          DF.literal('o'),
+        ))).toEqual([
+          DF.quad(
+            DF.namedNode('http://something.ldbc.eu/a.ttl'),
+            DF.namedNode('ex:p'),
+            DF.literal('o'),
+          ),
+        ]);
+      });
+    });
+  });
+
+  describe('with a replace group', () => {
+    beforeEach(() => {
+      transformer = new QuadTransformerBlankToNamed(
+        '^http://www.ldbc.eu/data/pers([0-9]*)$',
+        'http://www.ldbc.eu/pods/$1/profile/card#me',
+      );
+    });
+
+    describe('transform', () => {
+      it('should modify applicable terms', async() => {
+        expect(transformer.transform(DF.quad(
+          DF.blankNode('http://www.ldbc.eu/data/pers0495'),
+          DF.namedNode('ex:p'),
+          DF.literal('o'),
+        ))).toEqual([
+          DF.quad(
+            DF.namedNode('http://www.ldbc.eu/pods/0495/profile/card#me'),
+            DF.namedNode('ex:p'),
+            DF.literal('o'),
+          ),
+        ]);
+      });
+    });
+  });
+});


### PR DESCRIPTION
This PR adds a transformer that can transform blank nodes to NamedNodes. Required for fixing: https://github.com/SolidBench/SolidBench.js/issues/9