### PR TITLE
Update action versions, adjust Node versions in the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           key: ${{ runner.os }}-lint-modules-${{ hashFiles('**/yarn.lock') }}
       - uses: actions/setup-node@v4
         with:
-          node-version: lts/*
+          node-version: 20.x
       - run: yarn install --frozen-lockfile
       - run: yarn run lint
 
@@ -31,11 +31,9 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         node-version:
-          - lts/-3
-          - lts/-2
-          - lts/-1
-          - lts/*
-          - latest
+          - 16.x
+          - 18.x
+          - 20.x
     steps:
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,15 +5,15 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/cache@v2
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-lint-modules-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
-          node-version: 14.x
-      - run: yarn install
+          node-version: lts/*
+      - run: yarn install --frozen-lockfile
       - run: yarn run lint
 
   test:
@@ -25,27 +25,22 @@ jobs:
           - 14.x
           - 16.x
           - 18.x
+          - 20.x
+          - latest
     steps:
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Ensure line endings are consistent
-        run: git config --global core.autocrlf input
-      - name: Check out repository
-        uses: actions/checkout@v2
-      - uses: actions/cache@v2
+      - run: git config --global core.autocrlf input
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-test-modules-${{ hashFiles('**/yarn.lock') }}
-      - name: Install dependencies
-        run: yarn install
-      - name: Build project
-        run: yarn run build
-      - name: Run tests
-        run: yarn run test
-      - name: Submit coverage results
-        uses: coverallsapp/github-action@master
+      - run: yarn install --frozen-lockfile
+      - run: yarn run build
+      - run: yarn run test
+      - uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.github_token }}
           flag-name: run-${{ matrix.node-version }}
@@ -55,8 +50,7 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - name: Consolidate test coverage from different jobs
-        uses: coverallsapp/github-action@master
+      - uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.github_token }}
           parallel-finished: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,13 @@
 name: CI
-on: [push, pull_request]
+
+on:
+  - push
+  - pull_request
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
       - run: yarn run lint
 
   test:
+    needs: lint
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,10 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         node-version:
-          - 14.x
-          - 16.x
-          - 18.x
-          - 20.x
+          - lts/-3
+          - lts/-2
+          - lts/-1
+          - lts/*
           - latest
     steps:
       - uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,6 @@ jobs:
           path: '**/node_modules'
           key: ${{ runner.os }}-test-modules-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --frozen-lockfile
-      - run: yarn run build
       - run: yarn run test
       - uses: coverallsapp/github-action@master
         with:


### PR DESCRIPTION
Here is a set of changes to:

* Update the actions versions to later ones, due to Node 14 being deprecated and the old actions still using that one.
* Always run the linting step on the latest LTS version of Node, denoted by `lts/*`.
* Run the tests on the latest LTS version of Node, three previous LTS versions (`lts/-n`), and the latest one.
* Use the `--frozen-lockfile` flag when installing, to make sure the lockfile has been synced with the package dependencies when the CI runs, otherwise throws an error.

Any feedback is welcome. :slightly_smiling_face: 