### PR TITLE
Add QuadTransformerDistributeIri

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,6 +430,51 @@ Options:
 * `"searchRegex"`: The regex to search for.
 * `"replacementString"`: The string to replace.
 
+#### Replace and Distribute IRI Quad Transformer
+
+A quad transformer that that replaces (parts of) IRIs, deterministically distributing the replacements over a list of multiple destination IRI based on a matched number.
+
+```json
+{
+  "transformers": [
+    {
+      "@type": "QuadTransformerDistributeIri",
+      "searchRegex": "^http://www.ldbc.eu",
+      "replacementStrings": [ 
+        "http://localhost:3000/www.ldbc.eu",
+        "http://localhost:3030/www.ldbc.eu",
+        "http://localhost:3060/www.ldbc.eu"
+      ]
+    }
+  ]
+}
+```
+
+This requires at least one group-based replacement, of which the first group must match a number.
+
+The matched number is used to choose one of the `replacementStrings` in a deterministic way: `replacementStrings[number % replacementStrings.length]`
+
+```json
+{
+  "transformers": [
+    {
+      "@type": "QuadTransformerDistributeIri",
+      "searchRegex": "^http://www.ldbc.eu/data/pers([0-9]*)$",
+      "replacementStrings": [
+        "https://one.example.com/users$1/profile/card#me",
+        "https://two.example.com/users$1/profile/card#me",
+        "https://three.example.com/users$1/profile/card#me",
+        "https://four.example.com/users$1/profile/card#me"
+      ]
+    }
+  ]
+}
+```
+
+Options:
+* `"searchRegex"`: The regex to search for. A group is identified via `()` in the search regex. There must be at least one group. The first group must match a number.
+* `"replacementStrings"`: A list of string to use as replacements. A reference to the matched group can be made via `$...`.
+
 #### Replace BlankNode by NamedNode Transformer
 
 A quad transformer that replaces BlankNodes by NamedNodes if the node-value changes when performing search/ replacement.

--- a/index.ts
+++ b/index.ts
@@ -35,6 +35,7 @@ export * from './lib/transform/QuadTransformerClone';
 export * from './lib/transform/QuadTransformerCompositeSequential';
 export * from './lib/transform/QuadTransformerCompositeVaryingResource';
 export * from './lib/transform/QuadTransformerDistinct';
+export * from './lib/transform/QuadTransformerDistributeIri';
 export * from './lib/transform/QuadTransformerIdentity';
 export * from './lib/transform/QuadTransformerRemapResourceIdentifier';
 export * from './lib/transform/QuadTransformerReplaceIri';

--- a/lib/transform/QuadTransformerDistributeIri.ts
+++ b/lib/transform/QuadTransformerDistributeIri.ts
@@ -28,9 +28,7 @@ export class QuadTransformerDistributeIri extends QuadTransformerTerms {
       const match = this.search.exec(term.value);
       if (match) {
         if (match.length < 2) {
-          throw new Error(`QuadTransformerDistributeIri error: The "searchRegex" did not contain any groups. ` +
-              `QuadTransformerDistributeIri requires at least one group-based replacement, ` +
-              `of which the first group must match a number.`);
+          throw new Error(`'searchRegex' did not contain any groups, while QuadTransformerDistributeIri requires at least one group-based replacement, of which the first group must match a number.`);
         }
         const nr = Number.parseInt(match[1], 10);
         if (Number.isNaN(nr)) {

--- a/lib/transform/QuadTransformerDistributeIri.ts
+++ b/lib/transform/QuadTransformerDistributeIri.ts
@@ -1,0 +1,34 @@
+import type * as RDF from '@rdfjs/types';
+import { DataFactory } from 'rdf-data-factory';
+import { QuadTransformerTerms } from './QuadTransformerTerms';
+
+const DF = new DataFactory();
+
+/**
+ * A quad transformer that distributes IRIs over multiple destination
+ * IRIs. It does so by interpreting the first capture group as a number
+ * and using replacementStrings[number % replacementStrings.length]
+ *
+ */
+export class QuadTransformerDistributeIri extends QuadTransformerTerms {
+  private readonly search: RegExp;
+  private readonly replacements: string[];
+
+  public constructor(searchRegex: string, replacementStrings: string[]) {
+    super();
+    this.search = new RegExp(searchRegex, 'u');
+    this.replacements = replacementStrings;
+  }
+
+  protected transformTerm(term: RDF.Term): RDF.Term {
+    if (term.termType === 'NamedNode') {
+      const match = this.search.exec(term.value);
+      if (match) {
+        const nr = Number.parseInt(match[1], 10);
+        const value = term.value.replace(this.search, this.replacements[nr % this.replacements.length]);
+        return DF.namedNode(value);
+      }
+    }
+    return term;
+  }
+}

--- a/lib/transform/QuadTransformerDistributeIri.ts
+++ b/lib/transform/QuadTransformerDistributeIri.ts
@@ -32,8 +32,7 @@ export class QuadTransformerDistributeIri extends QuadTransformerTerms {
         }
         const nr = Number.parseInt(match[1], 10);
         if (Number.isNaN(nr)) {
-          throw new Error(`QuadTransformerDistributeIri error: The first capture group in "searchRegex"` +
-              ` must always match a number, but it matched "${match[1]}" instead.`);
+          throw new Error(`The first capture group in 'searchRegex' must always match a number, but it matched "${match[1]}" instead.`);
         }
         const value = term.value.replace(this.search, this.replacements[nr % this.replacements.length]);
         return DF.namedNode(value);

--- a/test/unit/transform/QuadTransformerDistributeIri-test.ts
+++ b/test/unit/transform/QuadTransformerDistributeIri-test.ts
@@ -1,0 +1,46 @@
+import { DataFactory } from 'rdf-data-factory';
+import type { IQuadTransformer } from '../../../lib/transform/IQuadTransformer';
+import { QuadTransformerDistributeIri } from '../../../lib/transform/QuadTransformerDistributeIri';
+
+const DF = new DataFactory();
+
+describe('QuadTransformerDistributeIri', () => {
+  let transformer: IQuadTransformer;
+
+  describe('with a replace group', () => {
+    beforeEach(() => {
+      transformer = new QuadTransformerDistributeIri(
+        '^http://www.ldbc.eu/data/pers([0-9]*)$',
+        [ 'http://server1.ldbc.eu/pods/$1/profile/card#me', 'http://server2.ldbc.eu/pods/$1/profile/card#me' ],
+      );
+    });
+
+    describe('transform', () => {
+      it('should modify applicable terms', async() => {
+        expect(transformer.transform(DF.quad(
+          DF.namedNode('http://www.ldbc.eu/data/pers0494'),
+          DF.namedNode('ex:p'),
+          DF.literal('o'),
+        ))).toEqual([
+          DF.quad(
+            DF.namedNode('http://server1.ldbc.eu/pods/0494/profile/card#me'),
+            DF.namedNode('ex:p'),
+            DF.literal('o'),
+          ),
+        ]);
+
+        expect(transformer.transform(DF.quad(
+          DF.namedNode('http://www.ldbc.eu/data/pers0495'),
+          DF.namedNode('ex:p'),
+          DF.literal('o'),
+        ))).toEqual([
+          DF.quad(
+            DF.namedNode('http://server2.ldbc.eu/pods/0495/profile/card#me'),
+            DF.namedNode('ex:p'),
+            DF.literal('o'),
+          ),
+        ]);
+      });
+    });
+  });
+});

--- a/test/unit/transform/QuadTransformerDistributeIri-test.ts
+++ b/test/unit/transform/QuadTransformerDistributeIri-test.ts
@@ -41,6 +41,48 @@ describe('QuadTransformerDistributeIri', () => {
           ),
         ]);
       });
+
+      describe('transform', () => {
+        it('should not modify non-applicable terms', async() => {
+          expect(transformer.transform(DF.quad(
+            DF.namedNode('http://www.ldbc.eu/data/nr0494'),
+            DF.namedNode('ex:p'),
+            DF.literal('o'),
+          ))).toEqual([
+            DF.quad(
+              DF.namedNode('http://www.ldbc.eu/data/nr0494'),
+              DF.namedNode('ex:p'),
+              DF.literal('o'),
+            ),
+          ]);
+        });
+
+        it('should throw error for first regex group not capturing number', async() => {
+          const badTransformer = new QuadTransformerDistributeIri(
+            '^http://www.ldbc.eu/data/(pers[0-9]*)$',
+            [ 'http://server1.ldbc.eu/pods/$1/profile/card#me', 'http://server2.ldbc.eu/pods/$1/profile/card#me' ],
+          );
+
+          expect(() => badTransformer.transform(DF.quad(
+            DF.namedNode('http://www.ldbc.eu/data/pers0495'),
+            DF.namedNode('ex:p'),
+            DF.literal('o'),
+          ))).toThrow();
+        });
+
+        it('should throw error when no regex groups', async() => {
+          const badTransformer = new QuadTransformerDistributeIri(
+            '^http://www.ldbc.eu/data/pers[0-9]*$',
+            [ 'http://server1.ldbc.eu/pods/$1/profile/card#me', 'http://server2.ldbc.eu/pods/$1/profile/card#me' ],
+          );
+
+          expect(() => badTransformer.transform(DF.quad(
+            DF.namedNode('http://www.ldbc.eu/data/pers0495'),
+            DF.namedNode('ex:p'),
+            DF.literal('o'),
+          ))).toThrow();
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
A quad transformer that distributes IRIs over multiple destination IRIs. It does so by interpreting the first capture group as a number and using `replacementStrings[number % replacementStrings.length]`

(credit @twalcari)