### PR TITLE
constant strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ A fragmentation stratety that delegates all quads towards a single path.
 {
   "fragmentationStrategy": {
     "@type": "FragmentationConstant",
-    "locationIri": "http://localhost:3000/datadump"
+    "path": "http://localhost:3000/datadump"
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -225,7 +225,17 @@ except for predicate1 and predicate2 that will be delegated to the object-based 
   }
 }
 ```
+#### Constant Fragmentation Strategy
+A fragmentation stratety that put all the quads in one resources defined by the config.
 
+```json
+{
+  "fragmentationStrategy": {
+    "@type": "FragmentationConstant",
+    "locationIri": "http://localhost:3000/datadump"
+  }
+}
+```
 ### Quad Sinks
 
 A quad sink is able to direct a stream of quads as output from the fragmentation process.

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ except for predicate1 and predicate2 that will be delegated to the object-based 
 }
 ```
 #### Constant Fragmentation Strategy
-A fragmentation stratety that put all the quads in one resources defined by the config.
+A fragmentation stratety that delegates all quads towards a single path.
 
 ```json
 {

--- a/index.ts
+++ b/index.ts
@@ -17,6 +17,7 @@ export * from './lib/strategy/FragmentationStrategyObject';
 export * from './lib/strategy/FragmentationStrategyResourceObject';
 export * from './lib/strategy/FragmentationStrategyStreamAdapter';
 export * from './lib/strategy/FragmentationStrategySubject';
+export * from './lib/strategy/FragmentationConstant';
 export * from './lib/strategy/IFragmentationStrategy';
 export * from './lib/transform/termtemplate/ITermTemplate';
 export * from './lib/transform/termtemplate/TermTemplateQuadComponent';

--- a/lib/strategy/FragmentationConstant.ts
+++ b/lib/strategy/FragmentationConstant.ts
@@ -9,8 +9,7 @@ export class FragmentationConstant extends FragmentationStrategyStreamAdapter {
   public readonly locationIri: string;
 
   /**
-   *
-   * @param locationIri - the iri of the resource where the quads going to be materialized
+   * @param {string} locationIri - the iri of the resource where the quads going to be materialized
    */
   public constructor(locationIri: string) {
     super();

--- a/lib/strategy/FragmentationConstant.ts
+++ b/lib/strategy/FragmentationConstant.ts
@@ -3,7 +3,7 @@ import type { IQuadSink } from '../io/IQuadSink';
 import { FragmentationStrategyStreamAdapter } from './FragmentationStrategyStreamAdapter';
 
 /**
- * A fragmentation strategy that places quads into one file.
+ * A fragmentation strategy that delegates all quads towards a single path.
  */
 export class FragmentationConstant extends FragmentationStrategyStreamAdapter {
   public readonly locationIri: string;

--- a/lib/strategy/FragmentationConstant.ts
+++ b/lib/strategy/FragmentationConstant.ts
@@ -6,17 +6,17 @@ import { FragmentationStrategyStreamAdapter } from './FragmentationStrategyStrea
  * A fragmentation strategy that delegates all quads towards a single path.
  */
 export class FragmentationConstant extends FragmentationStrategyStreamAdapter {
-  public readonly locationIri: string;
+  public readonly path: string;
 
   /**
-   * @param {string} locationIri - the iri of the resource where the quads going to be materialized
+   * @param {string} path - the iri of the resource where the quads going to be materialized
    */
-  public constructor(locationIri: string) {
+  public constructor(path: string) {
     super();
-    this.locationIri = locationIri;
+    this.path = path;
   }
 
   protected async handleQuad(quad: RDF.Quad, quadSink: IQuadSink): Promise<void> {
-    await quadSink.push(this.locationIri, quad);
+    await quadSink.push(this.path, quad);
   }
 }

--- a/lib/strategy/FragmentationConstant.ts
+++ b/lib/strategy/FragmentationConstant.ts
@@ -1,0 +1,23 @@
+import type * as RDF from '@rdfjs/types';
+import type { IQuadSink } from '../io/IQuadSink';
+import { FragmentationStrategyStreamAdapter } from './FragmentationStrategyStreamAdapter';
+
+/**
+ * A fragmentation strategy that places quads into one file.
+ */
+export class FragmentationConstant extends FragmentationStrategyStreamAdapter {
+  public readonly locationIri: string;
+
+  /**
+   *
+   * @param locationIri - the iri of the resource where the quads going to be materialized
+   */
+  public constructor(locationIri: string) {
+    super();
+    this.locationIri = locationIri;
+  }
+
+  protected async handleQuad(quad: RDF.Quad, quadSink: IQuadSink): Promise<void> {
+    await quadSink.push(this.locationIri, quad);
+  }
+}

--- a/test/unit/strategy/FragmentationConstant.ts-test.ts
+++ b/test/unit/strategy/FragmentationConstant.ts-test.ts
@@ -10,21 +10,21 @@ describe('FragmentationConstant', () => {
   let sink: any;
   describe('constructor', () => {
     it('should construct', () => {
-      const locationIri = 'bar';
+      const path = 'bar';
 
-      const strategy = new FragmentationConstant(locationIri);
+      const strategy = new FragmentationConstant(path);
 
       expect(strategy).toBeDefined();
-      expect(strategy.locationIri).toBe(locationIri);
+      expect(strategy.path).toBe(path);
     });
   });
 
   describe('fragment', () => {
-    const locationIri = 'bar';
+    const path = 'bar';
     let strategy: any;
 
     beforeEach(() => {
-      strategy = new FragmentationConstant(locationIri);
+      strategy = new FragmentationConstant(path);
       sink = {
         push: jest.fn(),
       };
@@ -63,7 +63,7 @@ describe('FragmentationConstant', () => {
 
       for (const [ i, quad ] of quads.entries()) {
         expect(sink.push).toHaveBeenNthCalledWith(i + 1,
-          strategy.locationIri,
+          strategy.path,
           quad);
       }
     });

--- a/test/unit/strategy/FragmentationConstant.ts-test.ts
+++ b/test/unit/strategy/FragmentationConstant.ts-test.ts
@@ -1,0 +1,71 @@
+import { DataFactory } from 'rdf-data-factory';
+import { FragmentationConstant }
+  from '../../../lib/strategy/FragmentationConstant';
+
+const streamifyArray = require('streamify-array');
+
+const DF = new DataFactory();
+
+describe('FragmentationConstant', () => {
+  let sink: any;
+  describe('constructor', () => {
+    it('should construct', () => {
+      const locationIri = 'bar';
+
+      const strategy = new FragmentationConstant(locationIri);
+
+      expect(strategy).toBeDefined();
+      expect(strategy.locationIri).toBe(locationIri);
+    });
+  });
+
+  describe('fragment', () => {
+    const locationIri = 'bar';
+    let strategy: any;
+
+    beforeEach(() => {
+      strategy = new FragmentationConstant(locationIri);
+      sink = {
+        push: jest.fn(),
+      };
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('should not handle an empty stream', async() => {
+      await strategy.fragment(streamifyArray([]), sink);
+      expect(sink.push).not.toHaveBeenCalled();
+    });
+
+    it('should handle quads', async() => {
+      const quads = [
+        DF.quad(
+          DF.blankNode(),
+          DF.namedNode('foo'),
+          DF.namedNode('bar'),
+        ),
+        DF.quad(
+          DF.blankNode(),
+          DF.namedNode('foo1'),
+          DF.namedNode('bar1'),
+        ),
+        DF.quad(
+          DF.blankNode(),
+          DF.namedNode('foo2'),
+          DF.namedNode('bar2'),
+        ),
+      ];
+      await strategy.fragment(streamifyArray([ ...quads ]), sink);
+
+      expect(sink.push).toHaveBeenCalledTimes(quads.length);
+
+      for (const [ i, quad ] of quads.entries()) {
+        expect(sink.push).toHaveBeenNthCalledWith(i + 1,
+          strategy.locationIri,
+          quad);
+      }
+    });
+  });
+});


### PR DESCRIPTION
A fragmentation strategy to insert every quads into one file.
When using with Solidbench the memory has to be increase a bit. For me it has worked with `node --max-old-space-size=10384` but it might work with lower values. In the config the auxiliary fragmentation also have to be considered to truly have every quads in one files.

close #28