### PR TITLE
Move @types/bloem from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "@rdfjs/types": "*",
     "@types/async-lock": "^1.4.0",
+    "@types/bloem": "^0.2.0",
     "async-lock": "^1.4.0",
     "bloem": "^0.2.0",
     "componentsjs": "^5.0.0",
@@ -49,7 +50,6 @@
   },
   "devDependencies": {
     "@rubensworks/eslint-config": "^2.0.0",
-    "@types/bloem": "^0.2.0",
     "@types/jest": "^29.0.0",
     "arrayify-stream": "^2.0.0",
     "componentsjs-generator": "^3.0.0",


### PR DESCRIPTION
This is a fix for the types missing from the package when acquired via NPM, I did not have this issue locally so I missed it. Sorry about that. :/