### PR TITLE
Use regular expression matching in QuadSinkFile and prioritise longest match

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ The config file that should be passed to the command line tool has the following
     "log": true,
     "outputFormat": "application/n-quads",
     "iriToPath": {
-      "http://example.org/base/": "output/base/",
-      "http://example.org/other/": "output/other/"
+      "^http://example.org/base/": "output/base/",
+      "^http://example.org/other/": "output/other/"
     }
   }
 }
@@ -285,7 +285,7 @@ A quad sink is able to direct a stream of quads as output from the fragmentation
 
 #### File Quad Sink
 
-A quad sink that writes to files using an IRI to local file system path mapping.
+A quad sink that writes to files using an IRI to local file system path mapping with regular expressions.
 
 ```json
 {
@@ -295,8 +295,8 @@ A quad sink that writes to files using an IRI to local file system path mapping.
     "outputFormat": "application/n-quads",
     "fileExtension": "$.nq",
     "iriToPath": {
-      "http://example.org/base/": "output/base/",
-      "http://example.org/other/": "output/other/"
+      "^http://example.org/base/": "output/base/",
+      "^http://example.org/other/": "output/other/"
     }
   }
 }
@@ -359,8 +359,8 @@ A quad sink that combines multiple quad sinks.
         "outputFormat": "application/n-quads",
         "fileExtension": "$.nq",
         "iriToPath": {
-          "http://example.org/base/": "output/base/",
-          "http://example.org/other/": "output/other/"
+          "^http://example.org/base/": "output/base/",
+          "^http://example.org/other/": "output/other/"
         }
       },
       {
@@ -369,8 +369,8 @@ A quad sink that combines multiple quad sinks.
         "outputFormat": "application/n-quads",
         "fileExtension": "$.nq2",
         "iriToPath": {
-          "http://example.org/base/": "output-2/base/",
-          "http://example.org/other/": "output-2/other/"
+          "^http://example.org/base/": "output-2/base/",
+          "^http://example.org/other/": "output-2/other/"
         }
       }
     ]
@@ -401,8 +401,8 @@ A quad sink that wraps over another quad sink and only passes the quads through 
         "outputFormat": "application/n-quads",
         "fileExtension": "$.nq",
         "iriToPath": {
-          "http://example.org/base/": "output/base/",
-          "http://example.org/other/": "output/other/"
+          "^http://example.org/base/": "output/base/",
+          "^http://example.org/other/": "output/other/"
         }
       }
     ]

--- a/lib/io/QuadSinkFile.ts
+++ b/lib/io/QuadSinkFile.ts
@@ -1,4 +1,3 @@
-import * as readline from 'node:readline';
 import type { Writable } from 'node:stream';
 import type * as RDF from '@rdfjs/types';
 import type { IQuadSink } from './IQuadSink';
@@ -9,7 +8,7 @@ import { ParallelFileWriter } from './ParallelFileWriter';
  */
 export class QuadSinkFile implements IQuadSink {
   private readonly outputFormat: string;
-  private readonly iriToPath: Record<string, string>;
+  private readonly iriToPath: Map<RegExp, string>;
   private readonly fileWriter: ParallelFileWriter;
   protected readonly log: boolean;
   protected readonly fileExtension?: string;
@@ -18,19 +17,18 @@ export class QuadSinkFile implements IQuadSink {
 
   public constructor(options: IQuadSinkFileOptions) {
     this.outputFormat = options.outputFormat;
-    this.iriToPath = options.iriToPath;
+    this.iriToPath = new Map(Object.entries(options.iriToPath).map(([ exp, sub ]) => [
+      new RegExp(exp, 'u'),
+      sub,
+    ]));
     this.log = Boolean(options.log);
     this.fileExtension = options.fileExtension;
-
     this.fileWriter = new ParallelFileWriter({ streams: 128 });
-
     this.attemptLog();
   }
 
   protected attemptLog(newLine = false): void {
     if (this.log && (this.counter % 1_000 === 0 || newLine)) {
-      readline.clearLine(process.stdout, 0);
-      readline.cursorTo(process.stdout, 0);
       process.stdout.write(`\rHandled quads: ${this.counter / 1_000}K`);
       if (newLine) {
         process.stdout.write(`\n`);
@@ -46,20 +44,26 @@ export class QuadSinkFile implements IQuadSink {
     }
 
     // Find base path from the first matching baseIRI
-    let path: string | undefined;
-    for (const [ baseIRI, basePath ] of Object.entries(this.iriToPath)) {
-      if (iri.startsWith(baseIRI)) {
-        path = basePath + iri.slice(baseIRI.length);
-        break;
+    let bestMatch: RegExpExecArray | undefined;
+    let bestRegex: RegExp | undefined;
+
+    for (const exp of this.iriToPath.keys()) {
+      const match = exp.exec(iri);
+      if (match && (bestMatch === undefined || match[0].length > bestMatch[0].length)) {
+        bestMatch = match;
+        bestRegex = exp;
       }
     }
 
     // Crash if we did not find a matching baseIRI
-    if (!path) {
+    if (!bestRegex) {
       throw new Error(`No IRI mapping found for ${iri}`);
     }
 
-    // Escape illegal directory names
+    // Perform substitution and replace illegal directory names
+    let path = iri.replace(bestRegex, this.iriToPath.get(bestRegex)!);
+
+    // Replace illegal directory names
     path = path.replaceAll(/[*|"<>?:]/ug, '_');
 
     // Add file extension if we don't have one yet
@@ -90,11 +94,22 @@ export class QuadSinkFile implements IQuadSink {
 }
 
 export interface IQuadSinkFileOptions {
+  /**
+   * The RDF format to output, expressed as mimetype.
+   */
   outputFormat: string;
   /**
+   * Mapping of regular expressions to their replacements,
+   * for determining the file path from a given IRI.
    * @range {json}
    */
   iriToPath: Record<string, string>;
+  /**
+   * Whether to log quad handling progress.
+   */
   log?: boolean;
+  /**
+   * Optional file extension to use.
+   */
   fileExtension?: string;
 }

--- a/lib/io/QuadSinkFile.ts
+++ b/lib/io/QuadSinkFile.ts
@@ -1,3 +1,4 @@
+import { clearLine, cursorTo } from 'node:readline';
 import type { Writable } from 'node:stream';
 import type * as RDF from '@rdfjs/types';
 import type { IQuadSink } from './IQuadSink';
@@ -29,7 +30,9 @@ export class QuadSinkFile implements IQuadSink {
 
   protected attemptLog(newLine = false): void {
     if (this.log && (this.counter % 1_000 === 0 || newLine)) {
-      process.stdout.write(`\rHandled quads: ${this.counter / 1_000}K`);
+      clearLine(process.stdout, 0);
+      cursorTo(process.stdout, 0);
+      process.stdout.write(`Handled quads: ${this.counter / 1_000}K`);
       if (newLine) {
         process.stdout.write(`\n`);
       }

--- a/lib/io/QuadSinkFile.ts
+++ b/lib/io/QuadSinkFile.ts
@@ -32,7 +32,7 @@ export class QuadSinkFile implements IQuadSink {
     if (this.log && (this.counter % 1_000 === 0 || newLine)) {
       clearLine(process.stdout, 0);
       cursorTo(process.stdout, 0);
-      process.stdout.write(`Handled quads: ${this.counter / 1_000}K`);
+      process.stdout.write(`\rHandled quads: ${this.counter / 1_000}K`);
       if (newLine) {
         process.stdout.write(`\n`);
       }

--- a/test/unit/io/QuadSinkFile-test.ts
+++ b/test/unit/io/QuadSinkFile-test.ts
@@ -1,3 +1,4 @@
+import { clearLine, cursorTo } from 'node:readline';
 import type { Writable } from 'node:stream';
 import type * as RDF from '@rdfjs/types';
 import { DataFactory } from 'rdf-data-factory';
@@ -8,6 +9,7 @@ import { QuadSinkFile } from '../../../lib/io/QuadSinkFile';
 const DF = new DataFactory();
 
 jest.mock('../../../lib/io/ParallelFileWriter');
+jest.mock('node:readline');
 
 interface IQuadSinkFile extends IQuadSink {
   outputFormat: string;
@@ -72,21 +74,35 @@ describe('QuadSinkFile', () => {
 
     it('should properly log at intervals of 1000 when logging is on', () => {
       sink.log = true;
+      expect(clearLine).not.toHaveBeenCalled();
+      expect(cursorTo).not.toHaveBeenCalled();
       expect(process.stdout.write).not.toHaveBeenCalled();
       sink.attemptLog(false);
+      expect(clearLine).toHaveBeenCalledTimes(1);
+      expect(clearLine).toHaveBeenNthCalledWith(1, process.stdout, 0);
+      expect(cursorTo).toHaveBeenCalledTimes(1);
+      expect(cursorTo).toHaveBeenNthCalledWith(1, process.stdout, 0);
       expect(process.stdout.write).toHaveBeenCalledTimes(1);
-      expect(process.stdout.write).toHaveBeenNthCalledWith(1, '\rHandled quads: 0K');
+      expect(process.stdout.write).toHaveBeenNthCalledWith(1, 'Handled quads: 0K');
       sink.counter = 500;
       sink.attemptLog(false);
       expect(process.stdout.write).toHaveBeenCalledTimes(1);
       sink.counter = 1_000;
       sink.attemptLog(false);
+      expect(clearLine).toHaveBeenCalledTimes(2);
+      expect(clearLine).toHaveBeenNthCalledWith(2, process.stdout, 0);
+      expect(cursorTo).toHaveBeenCalledTimes(2);
+      expect(cursorTo).toHaveBeenNthCalledWith(2, process.stdout, 0);
       expect(process.stdout.write).toHaveBeenCalledTimes(2);
-      expect(process.stdout.write).toHaveBeenNthCalledWith(2, '\rHandled quads: 1K');
+      expect(process.stdout.write).toHaveBeenNthCalledWith(2, 'Handled quads: 1K');
       sink.counter = 2_001;
       sink.attemptLog(true);
+      expect(clearLine).toHaveBeenCalledTimes(3);
+      expect(clearLine).toHaveBeenNthCalledWith(3, process.stdout, 0);
+      expect(cursorTo).toHaveBeenCalledTimes(3);
+      expect(cursorTo).toHaveBeenNthCalledWith(3, process.stdout, 0);
       expect(process.stdout.write).toHaveBeenCalledTimes(4);
-      expect(process.stdout.write).toHaveBeenNthCalledWith(3, '\rHandled quads: 2.001K');
+      expect(process.stdout.write).toHaveBeenNthCalledWith(3, 'Handled quads: 2.001K');
       expect(process.stdout.write).toHaveBeenNthCalledWith(4, '\n');
     });
   });

--- a/test/unit/io/QuadSinkFile-test.ts
+++ b/test/unit/io/QuadSinkFile-test.ts
@@ -83,7 +83,7 @@ describe('QuadSinkFile', () => {
       expect(cursorTo).toHaveBeenCalledTimes(1);
       expect(cursorTo).toHaveBeenNthCalledWith(1, process.stdout, 0);
       expect(process.stdout.write).toHaveBeenCalledTimes(1);
-      expect(process.stdout.write).toHaveBeenNthCalledWith(1, 'Handled quads: 0K');
+      expect(process.stdout.write).toHaveBeenNthCalledWith(1, '\rHandled quads: 0K');
       sink.counter = 500;
       sink.attemptLog(false);
       expect(process.stdout.write).toHaveBeenCalledTimes(1);
@@ -94,7 +94,7 @@ describe('QuadSinkFile', () => {
       expect(cursorTo).toHaveBeenCalledTimes(2);
       expect(cursorTo).toHaveBeenNthCalledWith(2, process.stdout, 0);
       expect(process.stdout.write).toHaveBeenCalledTimes(2);
-      expect(process.stdout.write).toHaveBeenNthCalledWith(2, 'Handled quads: 1K');
+      expect(process.stdout.write).toHaveBeenNthCalledWith(2, '\rHandled quads: 1K');
       sink.counter = 2_001;
       sink.attemptLog(true);
       expect(clearLine).toHaveBeenCalledTimes(3);
@@ -102,7 +102,7 @@ describe('QuadSinkFile', () => {
       expect(cursorTo).toHaveBeenCalledTimes(3);
       expect(cursorTo).toHaveBeenNthCalledWith(3, process.stdout, 0);
       expect(process.stdout.write).toHaveBeenCalledTimes(4);
-      expect(process.stdout.write).toHaveBeenNthCalledWith(3, 'Handled quads: 2.001K');
+      expect(process.stdout.write).toHaveBeenNthCalledWith(3, '\rHandled quads: 2.001K');
       expect(process.stdout.write).toHaveBeenNthCalledWith(4, '\n');
     });
   });


### PR DESCRIPTION
This changes `QuadSinkFile` to use regular expression to string substitution mappings instead of basic prefix mapping. This should allow to, for example, map the contents of several URIs to a single file.

This PR also fixes #36 by prioritising longer regex matches.

This is a small change, but the PR looks too big because it is based off #38.