### PR TITLE
Add QuadMatcherTermValue

### DIFF
--- a/README.md
+++ b/README.md
@@ -951,6 +951,41 @@ Options:
 * `"type""`: Regular expression for type IRIs that need to be matched.
 * `"matchFullResource""`: If not only the quad containing the type must be matched, but also all other quads sharing the same subject of that quad.
 
+#### Term Value Matcher
+
+Matches a quad by the provided regex and the specified quad term's value,
+with an optional probability to only match a given share of quads that would otherwise match.
+
+```json
+{
+  "fragmentationStrategy": {
+    "@type": "FragmentationStrategyException",
+    "strategy": {
+      "@type": "FragmentationStrategySubject"
+    },
+    "exceptions": [
+      {
+        "@type": "FragmentationStrategyExceptionEntry",
+        "matcher": {
+          "@type": "QuadMatcherTermValue",
+          "valueRegex": "vocabulary/subject1",
+          "quadTerm": "subject",
+          "probability": 0.5
+        },
+        "strategy": {
+          "@type": "FragmentationStrategyObject"
+        }
+      }
+    ]
+  }
+}
+```
+
+Options:
+* `"valueRegex"`: Regular expression to use on the term value. Without a capturing group in the regex, the entire falue is used for the probability. When there is a capturing group, the match from that group is used for the probability.
+* `"quadTerm"`: The quad term to match, one of `subject`, `predicate`, `object` or `graph`.
+* `"probability"`: The probability that a matching quad actually mnatches.
+
 ### Value modifiers
 
 Different strategies for modifying RDF term values.

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -11,6 +11,7 @@ export * from './io/QuadSourceFile';
 export * from './quadmatcher/IQuadMatcher';
 export * from './quadmatcher/QuadMatcherPredicate';
 export * from './quadmatcher/QuadMatcherResourceType';
+export * from './quadmatcher/QuadMatcherTermValue';
 export * from './strategy/FragmentationBlankNodeBuffer';
 export * from './strategy/FragmentationStrategyComposite';
 export * from './strategy/FragmentationStrategyDatasetSummary';

--- a/lib/quadmatcher/QuadMatcherTermValue.ts
+++ b/lib/quadmatcher/QuadMatcherTermValue.ts
@@ -1,0 +1,34 @@
+import { hash } from 'node:crypto';
+import type * as RDF from '@rdfjs/types';
+import type { IQuadMatcher } from './IQuadMatcher';
+
+/**
+ * Matches a quad by the given predicate regex.
+ */
+export class QuadMatcherTermValue implements IQuadMatcher {
+  private readonly regex: RegExp;
+  private readonly term: RDF.QuadTermName;
+  private readonly probability: number;
+
+  /**
+   * @param quadTerm The quad term to match
+   * @param valueRegex The regular expression to use when matching
+   * @param probability The probability to match @range {float}
+   */
+  public constructor(quadTerm: RDF.QuadTermName, valueRegex: string, probability?: number) {
+    this.regex = new RegExp(valueRegex, 'u');
+    this.term = quadTerm;
+    this.probability = probability ?? 1;
+  }
+
+  public matches(quad: RDF.Quad): boolean {
+    const termValue = quad[this.term].value;
+    const termMatch = this.regex.exec(termValue);
+    if (termMatch) {
+      const hashDigest = hash('sha256', termMatch.at(1) ?? termValue, 'hex');
+      const hashValue = Number.parseInt(hashDigest, 16) / (2 ** 256);
+      return hashValue <= this.probability;
+    }
+    return false;
+  }
+}

--- a/test/unit/quadmatcher/QuadMatcherTermValue-test.ts
+++ b/test/unit/quadmatcher/QuadMatcherTermValue-test.ts
@@ -1,0 +1,40 @@
+import { randomBytes } from 'node:crypto';
+import { DataFactory } from 'rdf-data-factory';
+import { QuadMatcherTermValue } from '../../../lib/quadmatcher/QuadMatcherTermValue';
+
+const DF = new DataFactory();
+
+describe('QuadMatcherTermValue', () => {
+  const quad1 = DF.quad(DF.namedNode('ex:s1'), DF.namedNode('ex:p'), DF.namedNode('ex:o'));
+  const quad2 = DF.quad(DF.namedNode('ex:s2'), DF.namedNode('ex:p'), DF.namedNode('ex:o'));
+
+  describe('matches', () => {
+    it('handles noncapturing regex', () => {
+      const matcher = new QuadMatcherTermValue('subject', '^ex:s1$');
+      expect(matcher.matches(quad1)).toBeTruthy();
+      expect(matcher.matches(quad2)).toBeFalsy();
+    });
+
+    it('handles capturing regex', () => {
+      const matcher = new QuadMatcherTermValue('subject', '^(ex:s1)$');
+      expect(matcher.matches(quad1)).toBeTruthy();
+      expect(matcher.matches(quad2)).toBeFalsy();
+    });
+
+    it.each([ 0.2, 0.5, 0.8 ])('handles probability of %p', (probability: number) => {
+      const matcher = new QuadMatcherTermValue('subject', '^ex:s', probability);
+      const sample = 500;
+      let matched = 0;
+      for (let i = 0; i < sample; i++) {
+        const quad = DF.quad(DF.namedNode(`ex:s${randomBytes(10).toString('hex')}`), quad1.predicate, quad1.object);
+        const matches1 = matcher.matches(quad);
+        const matches2 = matcher.matches(quad);
+        expect(matches1).toBe(matches2);
+        if (matches1) {
+          matched++;
+        }
+      }
+      expect(matched / sample).toBeCloseTo(probability, 1);
+    });
+  });
+});


### PR DESCRIPTION
This adds `QuadMatcherTermValue`, a matcher that allows matching a quad term (subject, predicate, object, graph) value using a regex, with an optional deterministic probability.

Any feedback is welcome!