### PR TITLE
Add QuadTransformerBlankToFragment

### DIFF
--- a/README.md
+++ b/README.md
@@ -570,6 +570,35 @@ Options:
 * `"searchRegex"`: The regex to search for.
 * `"replacementString"`: The string to replace.
 
+#### Remap BlankNode Object to NamedNode Subject Fragment Transformer
+
+A quad transformer that remaps BlankNodes in object position to fragments on the first subject position NamedNodes they appear with.
+This mapper assumes that each object blank node appears with a subject named node.
+
+```json
+{
+  "transformers": [
+    {
+      "@type": "QuadTransformerBlankToFragment"
+    }
+  ]
+}
+```
+
+For example, for the following triples:
+
+```turtle
+<ex:s> <ex:p1> _:blank .
+_:blank <ex:p2> "o" .
+```
+
+The transformer would output the following:
+
+```turtle
+<ex:s> <ex:p1> <ex:s#blank> .
+<ex:s#blank> <ex:p2> "o" .
+```
+
 #### Remap Resource Identifier Transformer
 
 A quad transformer that matches all resources of the given type,

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -38,6 +38,7 @@ export * from './transform/QuadTransformerAppendResourceAdapter';
 export * from './transform/QuadTransformerAppendResourceLink';
 export * from './transform/QuadTransformerAppendResourceScl';
 export * from './transform/QuadTransformerAppendResourceSolidTypeIndex';
+export * from './transform/QuadTransformerBlankToFragment';
 export * from './transform/QuadTransformerBlankToNamed';
 export * from './transform/QuadTransformerClone';
 export * from './transform/QuadTransformerCompositeSequential';

--- a/lib/transform/QuadTransformerBlankToFragment.ts
+++ b/lib/transform/QuadTransformerBlankToFragment.ts
@@ -1,0 +1,37 @@
+import type * as RDF from '@rdfjs/types';
+import { DataFactory } from 'rdf-data-factory';
+import type { IQuadTransformer } from './IQuadTransformer';
+
+const DF = new DataFactory();
+
+/**
+ * A quad transformer that maps BlankNodes to fragments on the subject URI,
+ * based on the first subject that blank node appears with as an object.
+ */
+export class QuadTransformerBlankToFragment implements IQuadTransformer {
+  private readonly mappings: Record<string, RDF.NamedNode>;
+
+  public constructor() {
+    this.mappings = {};
+  }
+
+  public transform(quad: RDF.Quad): RDF.Quad[] {
+    if (
+      quad.subject.termType === 'NamedNode' &&
+      quad.object.termType === 'BlankNode' &&
+      this.mappings[quad.object.value] === undefined
+    ) {
+      const target = DF.namedNode(`${quad.subject.value.split('#')[0]}#${quad.object.value}`);
+      this.mappings[quad.object.value] = target;
+      return [ DF.quad(quad.subject, quad.predicate, target, quad.graph) ];
+    }
+    if (quad.subject.termType === 'BlankNode') {
+      const target = this.mappings[quad.subject.value];
+      if (target === undefined) {
+        throw new Error(`Unmapped blank node: ${quad.subject.value}`);
+      }
+      return [ DF.quad(target, quad.predicate, quad.object, quad.graph) ];
+    }
+    return [ quad ];
+  }
+}

--- a/test/unit/transform/QuadTransformerBlankToFragment-test.ts
+++ b/test/unit/transform/QuadTransformerBlankToFragment-test.ts
@@ -1,0 +1,34 @@
+import { DataFactory } from 'rdf-data-factory';
+import type { IQuadTransformer } from '../../../lib/transform/IQuadTransformer';
+import { QuadTransformerBlankToFragment } from '../../../lib/transform/QuadTransformerBlankToFragment';
+
+describe('QuadTransformerBlankToFragment', () => {
+  const DF = new DataFactory();
+
+  let transformer: IQuadTransformer;
+
+  beforeEach(() => {
+    transformer = new QuadTransformerBlankToFragment();
+  });
+
+  it('should ignore quads without blank nodes', () => {
+    const quad = DF.quad(DF.namedNode('ex:s'), DF.namedNode('ex:p'), DF.namedNode('ex:o'));
+    expect(transformer.transform(quad)).toEqual([ quad ]);
+  });
+
+  it('should map same blank node to same fragment on consecutive calls', () => {
+    const blankNode = DF.blankNode('o');
+    const mappedNode = DF.namedNode('ex:s#o');
+    const quad1 = DF.quad(DF.namedNode('ex:s'), DF.namedNode('ex:p'), blankNode);
+    const quad2 = DF.quad(blankNode, DF.namedNode('ex:p2'), DF.namedNode('ex:o2'));
+    const quad3 = DF.quad(blankNode, DF.namedNode('ex:p3'), DF.namedNode('ex:o3'));
+    expect(transformer.transform(quad1)).toEqual([ DF.quad(quad1.subject, quad1.predicate, mappedNode) ]);
+    expect(transformer.transform(quad2)).toEqual([ DF.quad(mappedNode, quad2.predicate, quad2.object) ]);
+    expect(transformer.transform(quad3)).toEqual([ DF.quad(mappedNode, quad3.predicate, quad3.object) ]);
+  });
+
+  it('should throw error on unmapped blank node', () => {
+    const quad = DF.quad(DF.blankNode(), DF.namedNode('ex:p'), DF.namedNode('ex:o'));
+    expect(() => transformer.transform(quad)).toThrow('Unmapped blank node');
+  });
+});


### PR DESCRIPTION
This adds a transformer to map blank nodes to fragment URIs on the subject URI they first appear with. The value of the blank node is used as the fragment. The purpose of this is to allow removing blank nodes from benchmark datasets if needed.

This is split off #45 to make reviewing easier.