### PR TITLE
Add TermTemplateQuadComponentLiteral

### DIFF
--- a/README.md
+++ b/README.md
@@ -988,6 +988,24 @@ The example below refers to the object of a quad.
 Options:
 * `"component"`: The quad component: `subject`, `predicate`, `object`, or `graph`.
 
+#### Quad Component Literal
+
+A term template that returns a literal with the given quad component's value.
+
+The example below refers to the object of a quad.
+
+```json
+{
+  "@type": "TermTemplateQuadComponentLiteral",
+  "component": "object"
+}
+```
+
+Options:
+* `"component"`: The quad component: `subject`, `predicate`, `object`, or `graph`.
+* `"datatype"`: The optional datatype URI to assign to the produced literal.
+* `"language"`: The language tag to assign to the produced literal.
+
 #### Static Named Node.
 
 A term template that always returns a Named Node with the given value.

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -28,6 +28,7 @@ export * from './summary/DatasetSummaryBloom';
 export * from './summary/DatasetSummaryVoID';
 export * from './transform/termtemplate/ITermTemplate';
 export * from './transform/termtemplate/TermTemplateQuadComponent';
+export * from './transform/termtemplate/TermTemplateQuadComponentLiteral';
 export * from './transform/termtemplate/TermTemplateStaticNamedNode';
 export * from './transform/value/IValueModifier';
 export * from './transform/value/ValueModifierRegexReplaceGroup';

--- a/lib/transform/termtemplate/TermTemplateQuadComponentLiteral.ts
+++ b/lib/transform/termtemplate/TermTemplateQuadComponentLiteral.ts
@@ -1,0 +1,37 @@
+import type * as RDF from '@rdfjs/types';
+import { DataFactory } from 'rdf-data-factory';
+import type { ITermTemplate } from './ITermTemplate';
+
+const DF = new DataFactory();
+
+/**
+ * A term template that returns a given quad's component.
+ */
+export class TermTemplateQuadComponentLiteral implements ITermTemplate {
+  private readonly component: RDF.QuadTermName;
+  private readonly languageOrDatatype?: string | RDF.NamedNode;
+
+  public constructor(options: ITermTemplateQuadComponentLiteralOptions) {
+    this.component = options.component;
+    this.languageOrDatatype = options.datatype ? DF.namedNode(options.datatype) : options.language;
+  }
+
+  public getTerm(quad: RDF.Quad): RDF.Term {
+    return DF.literal(quad[this.component].value, this.languageOrDatatype);
+  }
+}
+
+export interface ITermTemplateQuadComponentLiteralOptions {
+  /**
+   * The quad term to retrieve the value from.
+   */
+  component: RDF.QuadTermName;
+  /**
+   * Optional data type URI.
+   */
+  datatype?: string;
+  /**
+   * Optional language string.
+   */
+  language?: string;
+}

--- a/test/unit/transform/termtemplate/TermTemplateQuadComponentLiteral-test.ts
+++ b/test/unit/transform/termtemplate/TermTemplateQuadComponentLiteral-test.ts
@@ -1,0 +1,36 @@
+import type * as RDF from '@rdfjs/types';
+import { DataFactory } from 'rdf-data-factory';
+import {
+  TermTemplateQuadComponentLiteral,
+} from '../../../../lib/transform/termtemplate/TermTemplateQuadComponentLiteral';
+
+const DF = new DataFactory();
+
+describe('TermTemplateQuadComponentLiteral', () => {
+  const datatype = 'ex:datatype';
+  const language = 'en';
+  const terms: RDF.QuadTermName[] = [ 'subject', 'predicate', 'object', 'graph' ];
+  const quad = DF.quad(DF.namedNode('ex:s'), DF.namedNode('ex:p'), DF.namedNode('ex:o'), DF.namedNode('ex:g'));
+
+  describe.each(terms)('should produce a literal from the %s value', (component) => {
+    it('without datatype of language specified', () => {
+      const transformer = new TermTemplateQuadComponentLiteral({ component });
+      expect(transformer.getTerm(quad)).toEqual(DF.literal(quad[component].value));
+    });
+
+    it('with datatype specified', () => {
+      const transformer = new TermTemplateQuadComponentLiteral({ component, datatype });
+      expect(transformer.getTerm(quad)).toEqual(DF.literal(quad[component].value, DF.namedNode(datatype)));
+    });
+
+    it('with language specified', () => {
+      const transformer = new TermTemplateQuadComponentLiteral({ component, language });
+      expect(transformer.getTerm(quad)).toEqual(DF.literal(quad[component].value, language));
+    });
+
+    it('with datatype and language specified', () => {
+      const transformer = new TermTemplateQuadComponentLiteral({ component, datatype, language });
+      expect(transformer.getTerm(quad)).toEqual(DF.literal(quad[component].value, DF.namedNode(datatype)));
+    });
+  });
+});


### PR DESCRIPTION
This adds a term template that converts the value of the specified quad component into a literal, with an optional datatype or language tag assigned to it. This is a simpler version of the one in the other PR, but is enough for what I need for experiments, and is a lot cleaner implementation-wise, so I decided to make a PR for this one, instead.

This is split off from #45 to make reviewing easier.