### PR TITLE
Clean-ups to VoID and Bloom filter generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,6 @@ A fragmentation strategy that delegates all quads towards a single path.
 
 Fragmentation strategy that generates partial dataset descriptions
 using the standard [VoID vocabulary](https://www.w3.org/TR/void/).
-The dataset URIs are determined based on quad subject values using regular expressions.
 
 ```json
 {
@@ -256,12 +255,13 @@ The dataset URIs are determined based on quad subject values using regular expre
 }
 ```
 
+Options:
+* `"datasetPatterns"`: The regular expressions used on quad subjects to identify datasets.
+
 #### Bloom Filter Fragmentation Strategy
 
-Fragmentation strategy that generates Bloom filters to capture co-occurrence of resources and properties,
+Fragmentation strategy that generates Bloom filters to capture co-occurrence of resources and properties within a dataset,
 using the custom [membership filter vocabulary](http://semweb.mmlab.be/ns/membership).
-The filters are generated per-dataset, where the dataset URI is determined based on quad subject values using regular expressions.
-After generation, the summaries can be re-mapped to a different document URI.
 
 ```json
 {
@@ -278,6 +278,10 @@ After generation, the summaries can be re-mapped to a different document URI.
   }
 }
 ```
+
+Options:
+* `"datasetPatterns"`: The regular expressions used on quad subjects to identify datasets.
+* `"locationPatterns"`: Regular expressions used to group dataset Bloom filters.
 
 ### Quad Sinks
 

--- a/lib/strategy/FragmentationStrategyDatasetSummaryBloom.ts
+++ b/lib/strategy/FragmentationStrategyDatasetSummaryBloom.ts
@@ -1,8 +1,6 @@
 import { DatasetSummaryBloom } from '../summary/DatasetSummaryBloom';
-import {
-  FragmentationStrategyDatasetSummary,
-  type IFragmentationStrategyDatasetSummaryOptions,
-} from './FragmentationStrategyDatasetSummary';
+import type { IFragmentationStrategyDatasetSummaryOptions } from './FragmentationStrategyDatasetSummary';
+import { FragmentationStrategyDatasetSummary } from './FragmentationStrategyDatasetSummary';
 
 export class FragmentationStrategyDatasetSummaryBloom extends FragmentationStrategyDatasetSummary<DatasetSummaryBloom> {
   protected readonly hashBits: number;
@@ -13,19 +11,19 @@ export class FragmentationStrategyDatasetSummaryBloom extends FragmentationStrat
     super(options);
     this.hashBits = options.hashBits;
     this.hashCount = options.hashCount;
-    this.locationPatterns = options.locationPatterns.map(exp => new RegExp(exp, 'u'));
+    this.locationPatterns = options.locationPatterns.map(p => new RegExp(p, 'u'));
   }
 
   protected createSummary(dataset: string): DatasetSummaryBloom {
-    let iri = dataset;
+    let location = dataset;
     for (const exp of this.locationPatterns) {
       const match = exp.exec(dataset);
       if (match) {
-        iri = match[0];
+        location = match[0];
         break;
       }
     }
-    return new DatasetSummaryBloom({ dataset, iri, hashBits: this.hashBits, hashCount: this.hashCount });
+    return new DatasetSummaryBloom({ dataset, location, hashBits: this.hashBits, hashCount: this.hashCount });
   }
 }
 
@@ -39,7 +37,7 @@ export interface IFragmentationStrategyDatasetSummaryBloomOptions extends IFragm
    */
   hashCount: number;
   /**
-   * Regular expressions used to remap the filters to different locations.
+   * Regular expressions used to group Bloom filters together.
    */
   locationPatterns: string[];
 }

--- a/lib/strategy/FragmentationStrategyDatasetSummaryVoID.ts
+++ b/lib/strategy/FragmentationStrategyDatasetSummaryVoID.ts
@@ -1,11 +1,9 @@
 import { DatasetSummaryVoID } from '../summary/DatasetSummaryVoID';
-import {
-  FragmentationStrategyDatasetSummary,
-  type IFragmentationStrategyDatasetSummaryOptions,
-} from './FragmentationStrategyDatasetSummary';
+import { FragmentationStrategyDatasetSummary } from './FragmentationStrategyDatasetSummary';
+import type { IFragmentationStrategyDatasetSummaryOptions } from './FragmentationStrategyDatasetSummary';
 
 export class FragmentationStrategyDatasetSummaryVoID extends FragmentationStrategyDatasetSummary<DatasetSummaryVoID> {
-  public constructor(options: IFragmentationStrategyDatasetSummaryOptions) {
+  public constructor(options: IFragmentationStrategyDatasetSummaryVoIDOptions) {
     super(options);
   }
 
@@ -13,3 +11,5 @@ export class FragmentationStrategyDatasetSummaryVoID extends FragmentationStrate
     return new DatasetSummaryVoID({ dataset });
   }
 }
+
+export interface IFragmentationStrategyDatasetSummaryVoIDOptions extends IFragmentationStrategyDatasetSummaryOptions {}

--- a/test/unit/strategy/FragmentationStrategyDatasetSummaryBloom-test.ts
+++ b/test/unit/strategy/FragmentationStrategyDatasetSummaryBloom-test.ts
@@ -11,8 +11,6 @@ const streamifyArray = require('streamify-array');
 
 const DF = new DataFactory();
 
-// Jest.mock('../../../lib/io/ParallelFileWriter');
-
 describe('FragmentationStrategyDatasetSummaryBloom', () => {
   const quadsEmpty: RDF.Quad[] = [];
   const quadsNoBnodes = [
@@ -91,23 +89,13 @@ describe('FragmentationStrategyDatasetSummaryBloom', () => {
       expect(sink.push).toHaveBeenCalledWith(
         quadsNoBnodes[0].subject.value,
         DF.quad(
-          DF.namedNode('ex:s1#5670a76463f24908dfcba691d6fe9c79'),
-          DatasetSummaryBloom.RDF_TYPE,
-          DatasetSummaryBloom.MEM_CLASS_BLOOMFILTER,
-        ),
-      );
-      expect(sink.push).toHaveBeenCalledWith(
-        quadsNoBnodes[0].subject.value,
-        DF.quad(
-          DF.namedNode('ex:s1#86f1470729001d9d1238634dbb3c0b02'),
-          DatasetSummaryBloom.RDF_TYPE,
-          DatasetSummaryBloom.MEM_CLASS_BLOOMFILTER,
-        ),
-      );
-      expect(sink.push).toHaveBeenCalledWith(
-        quadsNoBnodes[0].subject.value,
-        DF.quad(
-          DF.namedNode('ex:s1#1ee9da61777dc6a7b1e94de682488194'),
+          DatasetSummaryBloom.createFragmentIri(
+            quadsNoBnodes[0].subject.value,
+            quadsNoBnodes[0].subject.value,
+            DatasetSummaryBloom.MEM_CLASS_BLOOMFILTER.value,
+            DatasetSummaryBloom.MEM_PROP_PROJECTEDRESOURCE.value,
+            quadsNoBnodes[0].object.value,
+          ),
           DatasetSummaryBloom.RDF_TYPE,
           DatasetSummaryBloom.MEM_CLASS_BLOOMFILTER,
         ),
@@ -115,23 +103,13 @@ describe('FragmentationStrategyDatasetSummaryBloom', () => {
       expect(sink.push).toHaveBeenCalledWith(
         quadsNoBnodes[2].subject.value,
         DF.quad(
-          DF.namedNode('ex:s2#fad260fe4a45ad63f49b6b9a47907644'),
-          DatasetSummaryBloom.RDF_TYPE,
-          DatasetSummaryBloom.MEM_CLASS_BLOOMFILTER,
-        ),
-      );
-      expect(sink.push).toHaveBeenCalledWith(
-        quadsNoBnodes[2].subject.value,
-        DF.quad(
-          DF.namedNode('ex:s2#e6dad3e7a620cc688224a5451e8bc628'),
-          DatasetSummaryBloom.RDF_TYPE,
-          DatasetSummaryBloom.MEM_CLASS_BLOOMFILTER,
-        ),
-      );
-      expect(sink.push).toHaveBeenCalledWith(
-        quadsNoBnodes[2].subject.value,
-        DF.quad(
-          DF.namedNode('ex:s2#82c6a02b37b658e2ae41a30d0e0f7a70'),
+          DatasetSummaryBloom.createFragmentIri(
+            quadsNoBnodes[2].subject.value,
+            quadsNoBnodes[2].subject.value,
+            DatasetSummaryBloom.MEM_CLASS_BLOOMFILTER.value,
+            DatasetSummaryBloom.MEM_PROP_PROJECTEDRESOURCE.value,
+            quadsNoBnodes[2].object.value,
+          ),
           DatasetSummaryBloom.RDF_TYPE,
           DatasetSummaryBloom.MEM_CLASS_BLOOMFILTER,
         ),
@@ -149,23 +127,13 @@ describe('FragmentationStrategyDatasetSummaryBloom', () => {
       expect(sink.push).toHaveBeenCalledWith(
         quadsOwnedBnode[0].subject.value,
         DF.quad(
-          DF.namedNode('ex:s1#5670a76463f24908dfcba691d6fe9c79'),
-          DatasetSummaryBloom.RDF_TYPE,
-          DatasetSummaryBloom.MEM_CLASS_BLOOMFILTER,
-        ),
-      );
-      expect(sink.push).toHaveBeenCalledWith(
-        quadsOwnedBnode[0].subject.value,
-        DF.quad(
-          DF.namedNode('ex:s1#86f1470729001d9d1238634dbb3c0b02'),
-          DatasetSummaryBloom.RDF_TYPE,
-          DatasetSummaryBloom.MEM_CLASS_BLOOMFILTER,
-        ),
-      );
-      expect(sink.push).toHaveBeenCalledWith(
-        quadsOwnedBnode[0].subject.value,
-        DF.quad(
-          DF.namedNode('ex:s1#1ee9da61777dc6a7b1e94de682488194'),
+          DatasetSummaryBloom.createFragmentIri(
+            quadsOwnedBnode[0].subject.value,
+            quadsOwnedBnode[0].subject.value,
+            DatasetSummaryBloom.MEM_CLASS_BLOOMFILTER.value,
+            DatasetSummaryBloom.MEM_PROP_PROJECTEDRESOURCE.value,
+            quadsOwnedBnode[1].object.value,
+          ),
           DatasetSummaryBloom.RDF_TYPE,
           DatasetSummaryBloom.MEM_CLASS_BLOOMFILTER,
         ),
@@ -178,23 +146,13 @@ describe('FragmentationStrategyDatasetSummaryBloom', () => {
       expect(sink.push).toHaveBeenCalledWith(
         quadsOwnedBnodeReverse[1].subject.value,
         DF.quad(
-          DF.namedNode('ex:s1#5670a76463f24908dfcba691d6fe9c79'),
-          DatasetSummaryBloom.RDF_TYPE,
-          DatasetSummaryBloom.MEM_CLASS_BLOOMFILTER,
-        ),
-      );
-      expect(sink.push).toHaveBeenCalledWith(
-        quadsOwnedBnodeReverse[1].subject.value,
-        DF.quad(
-          DF.namedNode('ex:s1#86f1470729001d9d1238634dbb3c0b02'),
-          DatasetSummaryBloom.RDF_TYPE,
-          DatasetSummaryBloom.MEM_CLASS_BLOOMFILTER,
-        ),
-      );
-      expect(sink.push).toHaveBeenCalledWith(
-        quadsOwnedBnodeReverse[1].subject.value,
-        DF.quad(
-          DF.namedNode('ex:s1#1ee9da61777dc6a7b1e94de682488194'),
+          DatasetSummaryBloom.createFragmentIri(
+            quadsOwnedBnodeReverse[1].subject.value,
+            quadsOwnedBnodeReverse[1].subject.value,
+            DatasetSummaryBloom.MEM_CLASS_BLOOMFILTER.value,
+            DatasetSummaryBloom.MEM_PROP_PROJECTEDRESOURCE.value,
+            quadsOwnedBnodeReverse[0].object.value,
+          ),
           DatasetSummaryBloom.RDF_TYPE,
           DatasetSummaryBloom.MEM_CLASS_BLOOMFILTER,
         ),
@@ -207,23 +165,13 @@ describe('FragmentationStrategyDatasetSummaryBloom', () => {
       expect(sink.push).toHaveBeenCalledWith(
         quadsOwnedBnodeChained[0].subject.value,
         DF.quad(
-          DF.namedNode('ex:s1#5670a76463f24908dfcba691d6fe9c79'),
-          DatasetSummaryBloom.RDF_TYPE,
-          DatasetSummaryBloom.MEM_CLASS_BLOOMFILTER,
-        ),
-      );
-      expect(sink.push).toHaveBeenCalledWith(
-        quadsOwnedBnodeChained[0].subject.value,
-        DF.quad(
-          DF.namedNode('ex:s1#86f1470729001d9d1238634dbb3c0b02'),
-          DatasetSummaryBloom.RDF_TYPE,
-          DatasetSummaryBloom.MEM_CLASS_BLOOMFILTER,
-        ),
-      );
-      expect(sink.push).toHaveBeenCalledWith(
-        quadsOwnedBnodeChained[0].subject.value,
-        DF.quad(
-          DF.namedNode('ex:s1#1ee9da61777dc6a7b1e94de682488194'),
+          DatasetSummaryBloom.createFragmentIri(
+            quadsOwnedBnodeChained[0].subject.value,
+            quadsOwnedBnodeChained[0].subject.value,
+            DatasetSummaryBloom.MEM_CLASS_BLOOMFILTER.value,
+            DatasetSummaryBloom.MEM_PROP_PROJECTEDRESOURCE.value,
+            quadsOwnedBnodeChained[3].object.value,
+          ),
           DatasetSummaryBloom.RDF_TYPE,
           DatasetSummaryBloom.MEM_CLASS_BLOOMFILTER,
         ),
@@ -236,23 +184,13 @@ describe('FragmentationStrategyDatasetSummaryBloom', () => {
       expect(sink.push).toHaveBeenCalledWith(
         quadsOwnedBnodeChainedReverse[3].subject.value,
         DF.quad(
-          DF.namedNode('ex:s1#5670a76463f24908dfcba691d6fe9c79'),
-          DatasetSummaryBloom.RDF_TYPE,
-          DatasetSummaryBloom.MEM_CLASS_BLOOMFILTER,
-        ),
-      );
-      expect(sink.push).toHaveBeenCalledWith(
-        quadsOwnedBnodeChainedReverse[3].subject.value,
-        DF.quad(
-          DF.namedNode('ex:s1#86f1470729001d9d1238634dbb3c0b02'),
-          DatasetSummaryBloom.RDF_TYPE,
-          DatasetSummaryBloom.MEM_CLASS_BLOOMFILTER,
-        ),
-      );
-      expect(sink.push).toHaveBeenCalledWith(
-        quadsOwnedBnodeChainedReverse[3].subject.value,
-        DF.quad(
-          DF.namedNode('ex:s1#1ee9da61777dc6a7b1e94de682488194'),
+          DatasetSummaryBloom.createFragmentIri(
+            quadsOwnedBnodeChainedReverse[3].subject.value,
+            quadsOwnedBnodeChainedReverse[3].subject.value,
+            DatasetSummaryBloom.MEM_CLASS_BLOOMFILTER.value,
+            DatasetSummaryBloom.MEM_PROP_PROJECTEDRESOURCE.value,
+            quadsOwnedBnodeChainedReverse[0].object.value,
+          ),
           DatasetSummaryBloom.RDF_TYPE,
           DatasetSummaryBloom.MEM_CLASS_BLOOMFILTER,
         ),
@@ -265,23 +203,13 @@ describe('FragmentationStrategyDatasetSummaryBloom', () => {
       expect(sink.push).toHaveBeenCalledWith(
         quadsOwnedBnodes[0].subject.value,
         DF.quad(
-          DF.namedNode('ex:s1#5670a76463f24908dfcba691d6fe9c79'),
-          DatasetSummaryBloom.RDF_TYPE,
-          DatasetSummaryBloom.MEM_CLASS_BLOOMFILTER,
-        ),
-      );
-      expect(sink.push).toHaveBeenCalledWith(
-        quadsOwnedBnodes[0].subject.value,
-        DF.quad(
-          DF.namedNode('ex:s1#86f1470729001d9d1238634dbb3c0b02'),
-          DatasetSummaryBloom.RDF_TYPE,
-          DatasetSummaryBloom.MEM_CLASS_BLOOMFILTER,
-        ),
-      );
-      expect(sink.push).toHaveBeenCalledWith(
-        quadsOwnedBnodes[0].subject.value,
-        DF.quad(
-          DF.namedNode('ex:s1#1ee9da61777dc6a7b1e94de682488194'),
+          DatasetSummaryBloom.createFragmentIri(
+            quadsOwnedBnodes[0].subject.value,
+            quadsOwnedBnodes[0].subject.value,
+            DatasetSummaryBloom.MEM_CLASS_BLOOMFILTER.value,
+            DatasetSummaryBloom.MEM_PROP_PROJECTEDRESOURCE.value,
+            quadsOwnedBnodes[1].object.value,
+          ),
           DatasetSummaryBloom.RDF_TYPE,
           DatasetSummaryBloom.MEM_CLASS_BLOOMFILTER,
         ),
@@ -289,36 +217,32 @@ describe('FragmentationStrategyDatasetSummaryBloom', () => {
       expect(sink.push).toHaveBeenCalledWith(
         quadsOwnedBnodes[2].subject.value,
         DF.quad(
-          DF.namedNode('ex:s2#fad260fe4a45ad63f49b6b9a47907644'),
-          DatasetSummaryBloom.RDF_TYPE,
-          DatasetSummaryBloom.MEM_CLASS_BLOOMFILTER,
-        ),
-      );
-      expect(sink.push).toHaveBeenCalledWith(
-        quadsOwnedBnodes[2].subject.value,
-        DF.quad(
-          DF.namedNode('ex:s2#e6dad3e7a620cc688224a5451e8bc628'),
-          DatasetSummaryBloom.RDF_TYPE,
-          DatasetSummaryBloom.MEM_CLASS_BLOOMFILTER,
-        ),
-      );
-      expect(sink.push).toHaveBeenCalledWith(
-        quadsOwnedBnodes[2].subject.value,
-        DF.quad(
-          DF.namedNode('ex:s2#82c6a02b37b658e2ae41a30d0e0f7a70'),
+          DatasetSummaryBloom.createFragmentIri(
+            quadsOwnedBnodes[2].subject.value,
+            quadsOwnedBnodes[2].subject.value,
+            DatasetSummaryBloom.MEM_CLASS_BLOOMFILTER.value,
+            DatasetSummaryBloom.MEM_PROP_PROJECTEDRESOURCE.value,
+            quadsOwnedBnodes[3].object.value,
+          ),
           DatasetSummaryBloom.RDF_TYPE,
           DatasetSummaryBloom.MEM_CLASS_BLOOMFILTER,
         ),
       );
     });
 
-    it('should handle a stream with owned blank nodes in the same document', async() => {
+    it('should handle a stream with multiple owned blank nodes in the same document', async() => {
       await strategy.fragment(streamifyArray([ ...quadsOwnedBnodeMultipleSameDoc ]), sink);
       expect(sink.push).toHaveBeenCalledTimes(43);
       expect(sink.push).toHaveBeenCalledWith(
         quadsOwnedBnodeMultipleSameDoc[0].subject.value,
         DF.quad(
-          DF.namedNode('ex:s1#5670a76463f24908dfcba691d6fe9c79'),
+          DatasetSummaryBloom.createFragmentIri(
+            quadsOwnedBnodeMultipleSameDoc[0].subject.value,
+            quadsOwnedBnodeMultipleSameDoc[0].subject.value,
+            DatasetSummaryBloom.MEM_CLASS_BLOOMFILTER.value,
+            DatasetSummaryBloom.MEM_PROP_PROJECTEDRESOURCE.value,
+            quadsOwnedBnodeMultipleSameDoc[1].object.value,
+          ),
           DatasetSummaryBloom.RDF_TYPE,
           DatasetSummaryBloom.MEM_CLASS_BLOOMFILTER,
         ),
@@ -326,52 +250,32 @@ describe('FragmentationStrategyDatasetSummaryBloom', () => {
       expect(sink.push).toHaveBeenCalledWith(
         quadsOwnedBnodeMultipleSameDoc[0].subject.value,
         DF.quad(
-          DF.namedNode('ex:s1#86f1470729001d9d1238634dbb3c0b02'),
-          DatasetSummaryBloom.RDF_TYPE,
-          DatasetSummaryBloom.MEM_CLASS_BLOOMFILTER,
-        ),
-      );
-      expect(sink.push).toHaveBeenCalledWith(
-        quadsOwnedBnodeMultipleSameDoc[0].subject.value,
-        DF.quad(
-          DF.namedNode('ex:s1#37665dc6c30042a0980b056780c6c354'),
-          DatasetSummaryBloom.RDF_TYPE,
-          DatasetSummaryBloom.MEM_CLASS_BLOOMFILTER,
-        ),
-      );
-      expect(sink.push).toHaveBeenCalledWith(
-        quadsOwnedBnodeMultipleSameDoc[0].subject.value,
-        DF.quad(
-          DF.namedNode('ex:s1#e70c38b4544f3df3820457c322876cec'),
+          DatasetSummaryBloom.createFragmentIri(
+            quadsOwnedBnodeMultipleSameDoc[0].subject.value,
+            quadsOwnedBnodeMultipleSameDoc[0].subject.value,
+            DatasetSummaryBloom.MEM_CLASS_BLOOMFILTER.value,
+            DatasetSummaryBloom.MEM_PROP_PROJECTEDRESOURCE.value,
+            quadsOwnedBnodeMultipleSameDoc[2].object.value,
+          ),
           DatasetSummaryBloom.RDF_TYPE,
           DatasetSummaryBloom.MEM_CLASS_BLOOMFILTER,
         ),
       );
     });
 
-    it('should handle a stream with owned blank node in multiple documents', async() => {
+    it('should handle a stream with a blank node owned by multiple documents', async() => {
       await strategy.fragment(streamifyArray([ ...quadsOwnedBnodeMultipleDiffDoc ]), sink);
       expect(sink.push).toHaveBeenCalledTimes(66);
       expect(sink.push).toHaveBeenCalledWith(
         quadsOwnedBnodeMultipleDiffDoc[0].subject.value,
         DF.quad(
-          DF.namedNode('ex:s1#5670a76463f24908dfcba691d6fe9c79'),
-          DatasetSummaryBloom.RDF_TYPE,
-          DatasetSummaryBloom.MEM_CLASS_BLOOMFILTER,
-        ),
-      );
-      expect(sink.push).toHaveBeenCalledWith(
-        quadsOwnedBnodeMultipleDiffDoc[0].subject.value,
-        DF.quad(
-          DF.namedNode('ex:s1#86f1470729001d9d1238634dbb3c0b02'),
-          DatasetSummaryBloom.RDF_TYPE,
-          DatasetSummaryBloom.MEM_CLASS_BLOOMFILTER,
-        ),
-      );
-      expect(sink.push).toHaveBeenCalledWith(
-        quadsOwnedBnodeMultipleDiffDoc[0].subject.value,
-        DF.quad(
-          DF.namedNode('ex:s1#1ee9da61777dc6a7b1e94de682488194'),
+          DatasetSummaryBloom.createFragmentIri(
+            quadsOwnedBnodeMultipleDiffDoc[0].subject.value,
+            quadsOwnedBnodeMultipleDiffDoc[0].subject.value,
+            DatasetSummaryBloom.MEM_CLASS_BLOOMFILTER.value,
+            DatasetSummaryBloom.MEM_PROP_PROJECTEDRESOURCE.value,
+            quadsOwnedBnodeMultipleDiffDoc[2].object.value,
+          ),
           DatasetSummaryBloom.RDF_TYPE,
           DatasetSummaryBloom.MEM_CLASS_BLOOMFILTER,
         ),
@@ -379,23 +283,13 @@ describe('FragmentationStrategyDatasetSummaryBloom', () => {
       expect(sink.push).toHaveBeenCalledWith(
         quadsOwnedBnodeMultipleDiffDoc[1].subject.value,
         DF.quad(
-          DF.namedNode('ex:s2#fad260fe4a45ad63f49b6b9a47907644'),
-          DatasetSummaryBloom.RDF_TYPE,
-          DatasetSummaryBloom.MEM_CLASS_BLOOMFILTER,
-        ),
-      );
-      expect(sink.push).toHaveBeenCalledWith(
-        quadsOwnedBnodeMultipleDiffDoc[1].subject.value,
-        DF.quad(
-          DF.namedNode('ex:s2#e6dad3e7a620cc688224a5451e8bc628'),
-          DatasetSummaryBloom.RDF_TYPE,
-          DatasetSummaryBloom.MEM_CLASS_BLOOMFILTER,
-        ),
-      );
-      expect(sink.push).toHaveBeenCalledWith(
-        quadsOwnedBnodeMultipleDiffDoc[1].subject.value,
-        DF.quad(
-          DF.namedNode('ex:s2#82c6a02b37b658e2ae41a30d0e0f7a70'),
+          DatasetSummaryBloom.createFragmentIri(
+            quadsOwnedBnodeMultipleDiffDoc[1].subject.value,
+            quadsOwnedBnodeMultipleDiffDoc[1].subject.value,
+            DatasetSummaryBloom.MEM_CLASS_BLOOMFILTER.value,
+            DatasetSummaryBloom.MEM_PROP_PROJECTEDRESOURCE.value,
+            quadsOwnedBnodeMultipleDiffDoc[2].object.value,
+          ),
           DatasetSummaryBloom.RDF_TYPE,
           DatasetSummaryBloom.MEM_CLASS_BLOOMFILTER,
         ),
@@ -405,18 +299,16 @@ describe('FragmentationStrategyDatasetSummaryBloom', () => {
     it('should handle a stream unowned blank node, and ignore it', async() => {
       await strategy.fragment(streamifyArray([ ...quadsUnownedBnode ]), sink);
       expect(sink.push).toHaveBeenCalledTimes(23);
-      expect(sink.push).toHaveBeenCalledWith(
-        quadsNoBnodes[0].subject.value,
+      expect(sink.push).not.toHaveBeenCalledWith(
+        quadsUnownedBnode[0].subject.value,
         DF.quad(
-          DF.namedNode('ex:s1#5670a76463f24908dfcba691d6fe9c79'),
-          DatasetSummaryBloom.RDF_TYPE,
-          DatasetSummaryBloom.MEM_CLASS_BLOOMFILTER,
-        ),
-      );
-      expect(sink.push).toHaveBeenCalledWith(
-        quadsNoBnodes[0].subject.value,
-        DF.quad(
-          DF.namedNode('ex:s1#86f1470729001d9d1238634dbb3c0b02'),
+          DatasetSummaryBloom.createFragmentIri(
+            quadsUnownedBnode[0].subject.value,
+            quadsUnownedBnode[0].subject.value,
+            DatasetSummaryBloom.MEM_CLASS_BLOOMFILTER.value,
+            DatasetSummaryBloom.MEM_PROP_PROJECTEDRESOURCE.value,
+            quadsUnownedBnode[1].object.value,
+          ),
           DatasetSummaryBloom.RDF_TYPE,
           DatasetSummaryBloom.MEM_CLASS_BLOOMFILTER,
         ),

--- a/test/unit/summary/DatasetSummaryBloom-test.ts
+++ b/test/unit/summary/DatasetSummaryBloom-test.ts
@@ -22,7 +22,7 @@ describe('DatasetSummaryCollectorBloom', () => {
   let collector: IDatasetSummary;
 
   beforeEach(() => {
-    collector = new DatasetSummaryBloom({ hashBits, hashCount, iri: dataset.value, dataset: dataset.value });
+    collector = new DatasetSummaryBloom({ hashBits, hashCount, dataset: dataset.value, location: dataset.value });
   });
 
   it('should properly register quads', async() => {

--- a/test/unit/summary/DatasetSummaryVoID-test.ts
+++ b/test/unit/summary/DatasetSummaryVoID-test.ts
@@ -1,14 +1,9 @@
-import { createHash } from 'node:crypto';
-import type * as RDF from '@rdfjs/types';
 import { DataFactory } from 'rdf-data-factory';
-import { termToString } from 'rdf-string';
 import type { IDatasetSummary } from '../../../lib/summary/DatasetSummary';
 import { DatasetSummaryVoID } from '../../../lib/summary/DatasetSummaryVoID';
 import 'jest-rdf';
 
 const DF = new DataFactory();
-
-const hashTerm = (term: RDF.Term): string => createHash('md5').update(termToString(term)).digest('hex');
 
 describe('DatasetSummaryVoID', () => {
   const dataset = DF.namedNode('http://example.org/');
@@ -23,9 +18,9 @@ describe('DatasetSummaryVoID', () => {
     DF.quad(DF.variable('s'), DF.variable('p'), DF.variable('o')),
   ];
 
-  const propertyPartitionRdfType = DF.namedNode(`${dataset.value}#${hashTerm(DatasetSummaryVoID.RDF_TYPE)}`);
-  const propertyPartitionPredicate = DF.namedNode(`${dataset.value}#${hashTerm(quadPredicate)}`);
-  const classPartition = DF.namedNode(`${dataset.value}#${hashTerm(quadClass)}`);
+  const propertyPartitionRdfType = DF.namedNode(`${dataset.value}#${DatasetSummaryVoID.hashString(DatasetSummaryVoID.RDF_TYPE.value)}`);
+  const propertyPartitionPredicate = DF.namedNode(`${dataset.value}#${DatasetSummaryVoID.hashString(quadPredicate.value)}`);
+  const classPartition = DF.namedNode(`${dataset.value}#${DatasetSummaryVoID.hashString(quadClass.value)}`);
 
   let collector: IDatasetSummary;
 


### PR DESCRIPTION
This is a small set of clean-ups to the dataset summary generation logic, to simplify the unit tests for future maintenance, and to replace the use of Node's crypto functions for hash generation with `imurmurhash`. The hashes in question are only used for fragment identifiers.