### PR TITLE
Fix QuadMatcherTermValue probability test

### DIFF
--- a/test/unit/quadmatcher/QuadMatcherTermValue-test.ts
+++ b/test/unit/quadmatcher/QuadMatcherTermValue-test.ts
@@ -41,7 +41,7 @@ describe('QuadMatcherTermValue', () => {
         regex: '^ex:s',
         probability,
       });
-      const sample = 400;
+      const sample = 1_000;
       let matched = 0;
       for (let i = 0; i < sample; i++) {
         const quad = DF.quad(DF.namedNode(`ex:s${randomBytes(16).toString('hex')}`), quad1.predicate, quad1.object);


### PR DESCRIPTION
This is a tiny fix to bump the test sample size for the probability to 1,000 from 400 to make sure the probability of getting a probability outside the margin of error is lower.