### PR TITLE
Mock MurmurHash3 in QuadMatcherTermValue tests

### DIFF
--- a/test/unit/quadmatcher/QuadMatcherTermValue-test.ts
+++ b/test/unit/quadmatcher/QuadMatcherTermValue-test.ts
@@ -1,8 +1,19 @@
-import { randomBytes } from 'node:crypto';
 import { DataFactory } from 'rdf-data-factory';
 import { QuadMatcherTermValue } from '../../../lib/quadmatcher/QuadMatcherTermValue';
 
 const DF = new DataFactory();
+
+// Mock the murmurhash, as used in the matcher, to return deterministic values.
+jest.mock<typeof import('imurmurhash')>('imurmurhash', () => {
+  return jest.fn().mockImplementation((text?: string | undefined) => {
+    return {
+      result: () => {
+        const num = Number.parseInt(text!, 10);
+        return Number.isInteger(num) ? num : 1;
+      },
+    };
+  });
+});
 
 describe('QuadMatcherTermValue', () => {
   const quad1 = DF.quad(DF.namedNode('ex:s1'), DF.namedNode('ex:p'), DF.namedNode('ex:o'));
@@ -35,24 +46,20 @@ describe('QuadMatcherTermValue', () => {
       expect(matcher.matches(quad2)).toBeFalsy();
     });
 
-    it.each([ 0.2, 0.5, 0.8 ])('handles probability of %p', (probability: number) => {
+    it.each([ 0, 0.2, 0.5, 0.8, 1 ])('handles probability of %f', (probability) => {
       const matcher = new QuadMatcherTermValue({
         term: 'subject',
-        regex: '^ex:s',
+        regex: '^ex:s([0-9]+)$',
         probability,
       });
-      const sample = 20_000;
-      let matched = 0;
-      for (let i = 0; i < sample; i++) {
-        const quad = DF.quad(DF.namedNode(`ex:s${randomBytes(16).toString('hex')}`), quad1.predicate, quad1.object);
+      const maxHashValue = Number.MAX_SAFE_INTEGER >>> 0;
+      for (let i = 0; i < 1; i += 0.1) {
+        const quad = DF.quad(DF.namedNode(`ex:s${Math.floor(i * maxHashValue)}`), quad1.predicate, quad1.object);
         const matches1 = matcher.matches(quad);
         const matches2 = matcher.matches(quad);
         expect(matches1).toBe(matches2);
-        if (matches1) {
-          matched++;
-        }
+        expect(matches1).toBe(i <= probability);
       }
-      expect(matched / sample).toBeCloseTo(probability, 1);
     });
   });
 });

--- a/test/unit/quadmatcher/QuadMatcherTermValue-test.ts
+++ b/test/unit/quadmatcher/QuadMatcherTermValue-test.ts
@@ -41,7 +41,7 @@ describe('QuadMatcherTermValue', () => {
         regex: '^ex:s',
         probability,
       });
-      const sample = 1_000;
+      const sample = 20_000;
       let matched = 0;
       for (let i = 0; i < sample; i++) {
         const quad = DF.quad(DF.namedNode(`ex:s${randomBytes(16).toString('hex')}`), quad1.predicate, quad1.object);


### PR DESCRIPTION
This should hopefully ensure the sample size is large enough to not fail unit tests at random.